### PR TITLE
Fix: Button returns to original size after click/tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ git clone https://github.com/hackclub/css.git
 2. Start up a server (or open the `index.html` file in your browser):
 
 ```sh
-python -m SimpleHTTPServer
+python -m SimpleHTTPServer #Python 2
+python3 -m http.server #Python 3
 ```
 
 And then visit http://0.0.0.0:8000 to see the site!

--- a/theme.css
+++ b/theme.css
@@ -198,7 +198,7 @@
     font-weight: var(--font-weight-body);
   }
   
-  button {
+button {
     cursor: pointer;
     font-family: inherit;
     font-weight: var(--font-weight-bold);
@@ -209,7 +209,9 @@
     box-shadow: var(--shadow-card);
     letter-spacing: var(--letter-spacing-headline);
     -webkit-tap-highlight-color: transparent;
-    transition: transform 0.125s ease-in-out, box-shadow 0.125s ease-in-out;
+    transition: transform 0.25s cubic-bezier(0.34, 1.64, 0.64, 1),
+      box-shadow 0.25s cubic-bezier(0.34, 1.64, 0.64, 1);
+    transform: none; /* Base transform: original size */
     box-sizing: border-box;
     margin: 0;
     min-width: 0;
@@ -229,11 +231,18 @@
     border: 0;
     font-size: var(--font-2);
   }
-  
+
   button:focus,
   button:hover {
     box-shadow: var(--shadow-elevated);
+  }
+
+  button:hover {
     transform: scale(1.0625);
+  }
+
+  button:active {
+    transform: scale(1.015);
   }
   
   button.lg {

--- a/theme.css
+++ b/theme.css
@@ -211,7 +211,7 @@ button {
     -webkit-tap-highlight-color: transparent;
     transition: transform 0.25s cubic-bezier(0.34, 1.64, 0.64, 1),
       box-shadow 0.25s cubic-bezier(0.34, 1.64, 0.64, 1);
-    transform: none; /* Base transform: original size */
+    transform: none;
     box-sizing: border-box;
     margin: 0;
     min-width: 0;

--- a/theme.css
+++ b/theme.css
@@ -245,6 +245,16 @@ button {
     transform: scale(1.015);
   }
   
+  @media (hover: none) {
+    button:hover {
+      transform: none;
+    }
+    
+    button:active {
+      transform: scale(0.95);
+    }
+  }
+  
   button.lg {
     font-size: var(--font-3)!important;
     line-height: var(--line-height-title);

--- a/theme.css
+++ b/theme.css
@@ -295,13 +295,29 @@ button {
   .card.interactive {
     text-decoration: none;
     -webkit-tap-highlight-color: transparent;
-    transition: transform 0.125s ease-in-out, box-shadow 0.125s ease-in-out;
+    transition: transform 0.25s cubic-bezier(0.34, 1.64, 0.64, 1),
+      box-shadow 0.25s cubic-bezier(0.34, 1.64, 0.64, 1);
+    transform: none;
+    box-shadow: var(--shadow-card);
   }
-  
+
   .card.interactive:hover,
   .card.interactive:focus {
     transform: scale(1.0625);
     box-shadow: var(--shadow-elevated);
+  }
+
+  .card.interactive:active {
+    transform: scale(1.015);
+  }
+
+  @media (hover: none) {
+    .card.interactive:hover {
+      transform: none;
+    }
+    .card.interactive:active {
+      transform: scale(0.95);
+    }
   }
   
   input,


### PR DESCRIPTION
buttons now only scale up on hover not just when focused which stops them from staying enlarged after a click or tap

this makes the button behavior more consistent and feels more natural especially on mobile devices where hover interactions are different and a button might stay focused (and previously, enlarged) after a tap

also switch to a custom cubic-bezier animation since the behavior is different & added a python3 command for readme :)